### PR TITLE
update test to use config from the wellKnownConfig

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -46,7 +46,10 @@ const setup = (
       {
         domain: 'auth0_domain',
         client_id: 'auth0_client_id',
-        redirect_uri: 'my_callback_url'
+        redirect_uri: 'my_callback_url',
+        oidcConfig: {
+          authorizeEndpoint: '/authorize'
+        }
       },
       config
     )

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -63,6 +63,15 @@ const webWorkerMatcher = expect.objectContaining({
 });
 
 const setup = async (clientOptions: Partial<Auth0ClientOptions> = {}) => {
+  const utils = require('../src/utils');
+  const spy = jest.spyOn(utils, 'getJSON').mockImplementation(() => {
+    return {
+      issuer: 'https://test.auth0.com/',
+      token_endpoint: 'https://example.com/oauth/token',
+      end_session_endpoint: 'https://example.com/v2/logout',
+      authorization_endpoint: 'https://example.com/authorize'
+    };
+  });
   const auth0 = await createAuth0Client({
     domain: TEST_DOMAIN,
     client_id: TEST_CLIENT_ID,
@@ -82,7 +91,6 @@ const setup = async (clientOptions: Partial<Auth0ClientOptions> = {}) => {
 
   const tokenVerifier = require('../src/jwt').verify;
   const transactionManager = getDefaultInstance('../src/transaction-manager');
-  const utils = require('../src/utils');
 
   utils.createQueryParams.mockReturnValue(TEST_QUERY_PARAMS);
   utils.encode.mockReturnValue(TEST_ENCODED_STATE);
@@ -124,6 +132,8 @@ const setup = async (clientOptions: Partial<Auth0ClientOptions> = {}) => {
     location: { href: '' },
     close: jest.fn()
   };
+
+  spy.mockRestore();
 
   return {
     auth0,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -119,6 +119,10 @@ export default class Auth0Client {
 
     this.tokenIssuer = this.options.oidcConfig?.issuer ?? `${this.domainUrl}/`;
 
+    // delete oidcConfig from the options now that we dont need it anymore
+    // if not deleted the config will be added to the queryParams
+    delete this.options.oidcConfig;
+
     this.defaultScope = getUniqueScopes(
       'openid',
       this.options?.advancedOptions?.defaultScope !== undefined


### PR DESCRIPTION
Update the tests to use mock config from the well-known/openid-configuration endpoint